### PR TITLE
Updates the UX to use IdxContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 - Interact now returns `Context` struct
 - Introspect requires a second parameter, `state *string`. This can be `nil` if you want the library to create a state for you.
 
-- `Context.interactionHandle` stores a string for the interaction handle. Can be retrieved with `Context.GetInteractionHandle()`
-- `Context.state` stores the state string. This can be set during `Interact` as the second parameter, and can be retrieved with `Context.GetState()`
-- `Context.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `Context.GetCodeVerifier()`
+- `Context.interactionHandle` stores a string for the interaction handle. Can be retrieved with `Context.InteractionHandle()`
+- `Context.state` stores the state string. This can be set during `Interact` as the second parameter, and can be retrieved with `Context.State()`
+- `Context.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `Context.CodeVerifier()`
 
 ## v0.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Introspect requires a second parameter, `state *string`. This can be `nil` if you want the library to create a state for you.
 
 - `Context.interactionHandle` stores a string for the interaction handle. Can be retrieved with `Context.GetInteractionHandle()`
-- `Context.state` stores the a state string. This can be set during `Interact` as the second parameter, and can be retrieved with `Context.GetState()`
+- `Context.state` stores the state string. This can be set during `Interact` as the second parameter, and can be retrieved with `Context.GetState()`
 - `Context.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `Context.GetCodeVerifier()`
 
 ## v0.1.0-beta.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
 ## v0.1.0-beta.2
-- Interact now returns `IdxContext` struct
+- Interact now returns `Context` struct
 - Introspect requires a second parameter, `state *string`. This can be `nil` if you want the library to create a state for you.
 
-- `IdxContext.interactionHandle` stores a string for the interaction handle. Can be retrieved with `IdxContext.GetInteractionHandle()`
-- `IdxContext.state` stores the a state string. This can be set during `Interact` as the second parameter, and can be retrieved with `IdxContext.GetState()`
-- `IdxContext.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `IdxContext.GetCodeVerifier()`
+- `Context.interactionHandle` stores a string for the interaction handle. Can be retrieved with `Context.GetInteractionHandle()`
+- `Context.state` stores the a state string. This can be set during `Interact` as the second parameter, and can be retrieved with `Context.GetState()`
+- `Context.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `Context.GetCodeVerifier()`
 
 ## v0.1.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.1.0-beta.2
+- Interact now returns `IdxContext` struct
+- Introspect requires a second parameter, `state *string`. This can be `nil` if you want the library to create a state for you.
+
+- `IdxContext.interactionHandle` stores a string for the interaction handle. Can be retrieved with `IdxContext.GetInteractionHandle()`
+- `IdxContext.state` stores the a state string. This can be set during `Interact` as the second parameter, and can be retrieved with `IdxContext.GetState()`
+- `IdxContext.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `IdxContext.GetCodeVerifier()`
+
 ## v0.1.0-beta.1
 
 - Initial version with basic functionality

--- a/README.md
+++ b/README.md
@@ -138,8 +138,8 @@ for !response.LoginSuccess() {
 
 // These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 exchangeForm := []byte(`{
-    "client_secret": "` + client.GetClientSecret() + `",
-    "code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+    "client_secret": "` + client.ClientSecret() + `",
+    "code_verifier": "` + idxContext.CodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `CodeVerifier()` which will return a string
 }`)
 tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 if err != nil {
@@ -285,8 +285,8 @@ fmt.Printf("ID Token: %+s\n", tokens.IDToken)
 		fmt.Println("Successful login!")
 		// These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 		exchangeForm := []byte(`{
-			"client_secret": "` + client.GetClientSecret() + `",
-			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+			"client_secret": "` + client.ClientSecret() + `",
+			"code_verifier": "` + idxContext.CodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `CodeVerifier()` which will return a string
 		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {
@@ -542,8 +542,8 @@ fmt.Printf("ID Token: %+s\n", tokens.IDToken)
 		fmt.Println("Successful login!")
         // get the token
 		exchangeForm := []byte(`{
-			"client_secret": "` + client.GetClientSecret() + `",
-			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+			"client_secret": "` + client.ClientSecret() + `",
+			"code_verifier": "` + idxContext.CodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `CodeVerifier()` which will return a string
 		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ if err != nil {
 }
 ```
 
-### Get Interation Handle
+### Get IdxContext
+The IdxContext is where we store the interactionHandle, state, and codeVerifier for your application for you.
 ```go
-interactionHandle, err := IDXClient.Interact(context.TODO())
+idxContext, err := IDXClient.Interact(context.TODO(), nil)
 if err != nil {
     fmt.Errorf("retriving an interaction handle failed", err)
 }
@@ -89,12 +90,12 @@ if err != nil {
     panic(err)
 }
 
-interactHandle, err := client.Interact(context.TODO())
+idxContext, err := client.Interact(context.TODO(), nil)
 if err != nil {
     panic(err)
 }
 
-response, err = client.Introspect(context.TODO(), interactHandle)
+response, err = client.Introspect(context.TODO(), idxContext)
 if err != nil {
     panic(err)
 }
@@ -137,17 +138,17 @@ for !response.LoginSuccess() {
 
 // These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 exchangeForm := []byte(`{
-    "client_secret": "` + client.config.Okta.IDX.ClientSecret + `", // This should be available off the client config this way
-    "code_verifier": "` + string(client.GetCodeVerifier()) + `" // We generate your code_verfier for you and store it in the client struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+    "client_secret": "` + client.GetClientSecret() + `",
+    "code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
 }`)
 tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 if err != nil {
     panic(err)
 }
 
-fmt.Printf("%+v\n", tokens)
-fmt.Printf("%+s\n", tokens.AccessToken)
-fmt.Printf("%+s\n", tokens.IDToken)
+fmt.Printf("Tokens: %+v\n", tokens)
+fmt.Printf("Access Token: %+s\n", tokens.AccessToken)
+fmt.Printf("ID Token: %+s\n", tokens.IDToken)
 ```
 
 #### Enroll + Login using password + email authenticator
@@ -166,12 +167,12 @@ fmt.Printf("%+s\n", tokens.IDToken)
 		panic(err)
 	}
 
-	interactHandle, err := client.Interact(context.TODO())
+	idxContext, err := client.Interact(context.TODO(), nil)
 	if err != nil {
 		panic(err)
 	}
 
-	response, err = client.Introspect(context.TODO(), interactHandle)
+	response, err = client.Introspect(context.TODO(), idxContext)
 	if err != nil {
 		panic(err)
 	}
@@ -284,9 +285,9 @@ fmt.Printf("%+s\n", tokens.IDToken)
 		fmt.Println("Successful login!")
 		// These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 		exchangeForm := []byte(`{
-            "client_secret": "` + client.config.Okta.IDX.ClientSecret + `", // This should be available off the client config this way
-            "code_verifier": "` + string(client.GetCodeVerifier()) + `" // We generate your code_verfier for you and store it in the client struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
-        }`)
+			"client_secret": "` + client.GetClientSecret() + `",
+			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {
 		    panic(err)
@@ -541,9 +542,9 @@ fmt.Printf("%+s\n", tokens.IDToken)
 		fmt.Println("Successful login!")
         // get the token
 		exchangeForm := []byte(`{
-		"client_secret": "` + client.GetClientSecret() + `",
-		"code_verifier": "` + string(client.GetCodeVerifier()[:]) + `"
-	}`)
+			"client_secret": "` + client.GetClientSecret() + `",
+			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {
 		    panic(err)
@@ -576,12 +577,12 @@ if err != nil {
     panic(err)
 }
 
-interactHandle, err := client.Interact(context.TODO())
+idxContext, err := client.Interact(context.TODO(), nil)
 if err != nil {
     panic(err)
 }
 
-response, err = client.Introspect(context.TODO(), interactHandle)
+response, err = client.Introspect(context.TODO(), idxContext)
 if err != nil {
     panic(err)
 }
@@ -646,12 +647,12 @@ if err != nil {
 		panic(err)
 	}
 
-	interactHandle, err := client.Interact(context.TODO())
+	idxContext, err := client.Interact(context.TODO(), nil)
 	if err != nil {
 		panic(err)
 	}
 
-	response, err = client.Introspect(context.TODO(), interactHandle)
+	response, err = client.Introspect(context.TODO(), idxContext)
 	if err != nil {
 		panic(err)
 	}

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ if err != nil {
 }
 ```
 
-### Get IdxContext
-The IdxContext is where we store the interactionHandle, state, and codeVerifier for your application for you.
+### Get Context
+The Context is where we store the interactionHandle, state, and codeVerifier for your application for you.
 ```go
 idxContext, err := IDXClient.Interact(context.TODO(), nil)
 if err != nil {
@@ -139,7 +139,7 @@ for !response.LoginSuccess() {
 // These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 exchangeForm := []byte(`{
     "client_secret": "` + client.GetClientSecret() + `",
-    "code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+    "code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
 }`)
 tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 if err != nil {
@@ -286,7 +286,7 @@ fmt.Printf("ID Token: %+s\n", tokens.IDToken)
 		// These properties are based on the `successWithInteractionCode` object, and the properties that you are required to fill out
 		exchangeForm := []byte(`{
 			"client_secret": "` + client.GetClientSecret() + `",
-			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
 		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {
@@ -543,7 +543,7 @@ fmt.Printf("ID Token: %+s\n", tokens.IDToken)
         // get the token
 		exchangeForm := []byte(`{
 			"client_secret": "` + client.GetClientSecret() + `",
-			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the IdxContext struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
+			"code_verifier": "` + idxContext.GetCodeVerifier() + `" // We generate your code_verfier for you and store it in the Context struct. You can gain access to it through the method `GetCodeVerifier()` which will return a string
 		}`)
 		tokens, err := response.SuccessResponse.ExchangeCode(context.Background(), exchangeForm)
 		if err != nil {

--- a/idx.go
+++ b/idx.go
@@ -37,7 +37,7 @@ import (
 /**
  * Current version of the package. This is used mainly for our User-Agent
  */
-const packageVersion = "0.1.0-beta.1"
+const packageVersion = "0.1.0-beta.2"
 
 var idx *Client
 

--- a/idx.go
+++ b/idx.go
@@ -77,19 +77,19 @@ func (c *Client) WithHTTPClient(client *http.Client) *Client {
 	return c
 }
 
-func (c *Client) GetClientSecret() string {
+func (c *Client) ClientSecret() string {
 	return c.config.Okta.IDX.ClientSecret
 }
 
-func (ictx *Context) GetCodeVerifier() string {
+func (ictx *Context) CodeVerifier() string {
 	return ictx.codeVerifier
 }
 
-func (ictx *Context) GetInteractionHandle() *InteractionHandle {
+func (ictx *Context) InteractionHandle() *InteractionHandle {
 	return ictx.interactionHandle
 }
 
-func (ictx *Context) GetState() string {
+func (ictx *Context) State() string {
 	return ictx.state
 }
 
@@ -155,7 +155,7 @@ func (c *Client) Interact(ctx context.Context, state *string) (*Context, error) 
 	}
 	idxContext.state = *state
 
-	_, err = h.Write([]byte(idxContext.GetCodeVerifier()))
+	_, err = h.Write([]byte(idxContext.CodeVerifier()))
 	if err != nil {
 		return nil, fmt.Errorf("failed to write codeVerifier: %w", err)
 	}
@@ -168,7 +168,7 @@ func (c *Client) Interact(ctx context.Context, state *string) (*Context, error) 
 	data.Set("code_challenge", codeChallenge)
 	data.Set("code_challenge_method", "S256")
 	data.Set("redirect_uri", c.config.Okta.IDX.RedirectURI)
-	data.Set("state", idxContext.GetState())
+	data.Set("state", idxContext.State())
 
 	endpoint := c.config.Okta.IDX.Issuer + "/v1/interact"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(data.Encode()))
@@ -214,7 +214,7 @@ func (c *Client) Introspect(ctx context.Context, idxContext *Context) (*Response
 		ictx = idxContext
 	}
 
-	body, err := json.Marshal(ictx.GetInteractionHandle())
+	body, err := json.Marshal(ictx.InteractionHandle())
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal interaction handle: %w", err)
 	}

--- a/idx_test.go
+++ b/idx_test.go
@@ -243,7 +243,7 @@ func TestClient_Introspect(t *testing.T) {
 			config:     testConfig(ts.URL),
 			httpClient: ts.Client(),
 		}
-		resp, err := client.Introspect(context.TODO(), &IdxContext{interactionHandle: &InteractionHandle{"abcd"}})
+		resp, err := client.Introspect(context.TODO(), &Context{interactionHandle: &InteractionHandle{"abcd"}})
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(resp.Remediation.RemediationOptions))
 		assert.Equal(t, 4, len(resp.Remediation.RemediationOptions[0].FormValues))
@@ -268,7 +268,7 @@ func TestClient_Introspect(t *testing.T) {
 			config:     testConfig(ts.URL),
 			httpClient: ts.Client(),
 		}
-		_, err := client.Introspect(context.TODO(), &IdxContext{interactionHandle: &InteractionHandle{"abcd"}})
+		_, err := client.Introspect(context.TODO(), &Context{interactionHandle: &InteractionHandle{"abcd"}})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "http call has failed")
 	})
@@ -282,7 +282,7 @@ func TestClient_Introspect(t *testing.T) {
 			config:     testConfig(ts.URL),
 			httpClient: ts.Client(),
 		}
-		_, err := client.Introspect(context.TODO(), &IdxContext{interactionHandle: &InteractionHandle{"abcd"}})
+		_, err := client.Introspect(context.TODO(), &Context{interactionHandle: &InteractionHandle{"abcd"}})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to unmarshal response body")
 	})
@@ -310,7 +310,7 @@ func TestClient_Introspect(t *testing.T) {
 			config:     testConfig(ts.URL),
 			httpClient: ts.Client(),
 		}
-		_, err := client.Introspect(context.TODO(), &IdxContext{interactionHandle: &InteractionHandle{"abcd"}})
+		_, err := client.Introspect(context.TODO(), &Context{interactionHandle: &InteractionHandle{"abcd"}})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), `the API returned an error: The session has expired.`)
 	})


### PR DESCRIPTION
- Interact now returns `IdxContext` struct
- Introspect requires a second parameter, `state *string`. This can be `nil` if you want the library to create a state for you.

- `IdxContext.interactionHandle` stores a string for the interaction handle. Can be retrieved with `IdxContext.GetInteractionHandle()`
- `IdxContext.state` stores the a state string. This can be set during `Interact` as the second parameter, and can be retrieved with `IdxContext.GetState()`
- `IdxContext.codeVerifier` stores the codeVerifier to be used during the token exchange. The library generates PKCE data for you and this can be accessed with `IdxContext.GetCodeVerifier()`