### PR TITLE
Okta Verify authenticator enrollment and login

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ configuration in okta.yaml (if any), and so on.
 | okta.idx.scopes       | OKTA_IDX_SCOPES       | The scopes requested for the access token. Format yaml: array of values. Format ENV: CSV values                      |
 | okta.idx.redirectUri  | OKTA_IDX_REDIRECTURI  | For most cases, this will not be used, but is still required to supply. You can put any configured redirectUri here. |
 
+### Debug/Development Properties
+
+| Environment Key  | Description                                                            |
+|------------------|------------------------------------------------------------------------|
+| DEBUG_IDX_CLIENT | Using httputil all http requests and responses are println'd to stderr |
+
 #### Yaml Configuration
 
 The configuration could be expressed in our okta.yaml configuration for SDK as follows:

--- a/enroll.go
+++ b/enroll.go
@@ -83,6 +83,15 @@ func (c *Client) InitProfileEnroll(ctx context.Context, up *UserProfile) (*Enrol
 	return er, nil
 }
 
+// EnrollmentSuccess Determines if the enrollment response represents an enrollment success.
+func (r *EnrollmentResponse) EnrollmentSuccess() bool {
+	if r.HasStep(EnrollmentStepSuccess) && len(r.availableSteps) == 1 {
+		return true
+	}
+
+	return false
+}
+
 // SetNewPassword sets new password for the user.
 func (r *EnrollmentResponse) SetNewPassword(ctx context.Context, password string) (*EnrollmentResponse, error) {
 	if !r.HasStep(EnrollmentStepPasswordSetup) {

--- a/enroll.go
+++ b/enroll.go
@@ -586,7 +586,6 @@ func (r *EnrollmentResponse) missingStepError(missingStep EnrollmentStep) (*Enro
 			steps = fmt.Sprintf("%s, ", steps)
 		}
 		steps = fmt.Sprintf("%s%q", steps, step)
-
 	}
 	return nil, fmt.Errorf("%q enrollment step is not available, please try one of %s", missingStep, steps)
 }

--- a/identify.go
+++ b/identify.go
@@ -62,7 +62,7 @@ func (c *Client) InitLogin(ctx context.Context) (*LoginResponse, error) {
 // Identify Perform identification.
 func (r *LoginResponse) Identify(ctx context.Context, ir *IdentifyRequest) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepIdentify) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepIdentify)
 	}
 	resp, err := idx.introspect(ctx, r.idxContext.InteractionHandle)
 	if err != nil {
@@ -91,7 +91,7 @@ func (r *LoginResponse) Identify(ctx context.Context, ir *IdentifyRequest) (*Log
 // SetNewPassword Set new password.
 func (r *LoginResponse) SetNewPassword(ctx context.Context, password string) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepSetupNewPassword) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepSetupNewPassword)
 	}
 	resp, err := setPassword(ctx, r.idxContext, "reenroll-authenticator", password)
 	if err != nil {
@@ -121,7 +121,7 @@ func (r *LoginResponse) WhereAmI(ctx context.Context) (*LoginResponse, error) {
 // OktaVerify Perform verification.
 func (r *LoginResponse) OktaVerify(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepOktaVerify) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepOktaVerify)
 	}
 	resp, err := idx.introspect(ctx, r.idxContext.InteractionHandle)
 	if err != nil {
@@ -174,7 +174,7 @@ loop:
 // was reset or wasn't set up previously.
 func (r *LoginResponse) GoogleAuthInitialVerify(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepGoogleAuthenticatorInitialVerification) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepGoogleAuthenticatorInitialVerification)
 	}
 	resp, err := enrollGoogleAuth(ctx, r.idxContext.InteractionHandle)
 	if err != nil {
@@ -191,7 +191,7 @@ func (r *LoginResponse) GoogleAuthInitialVerify(ctx context.Context) (*LoginResp
 
 func (r *LoginResponse) GoogleAuthConfirm(ctx context.Context, code string) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepGoogleAuthenticatorConfirmation) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepGoogleAuthenticatorConfirmation)
 	}
 	defer func() {
 		r.contextualData = nil
@@ -210,7 +210,7 @@ func (r *LoginResponse) ContextualData() *ContextualData {
 // ConfirmPhone Confirms a phone given the identification code.
 func (r *LoginResponse) ConfirmPhone(ctx context.Context, code string) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepPhoneConfirmation) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepPhoneConfirmation)
 	}
 	resp, err := r.confirmWithCode(ctx, "challenge-authenticator", code)
 	// this might indicate that a user set ups the phone for the first time
@@ -223,7 +223,7 @@ func (r *LoginResponse) ConfirmPhone(ctx context.Context, code string) (*LoginRe
 // VerifyPhone Triggers phone verification code emission.
 func (r *LoginResponse) VerifyPhone(ctx context.Context, option PhoneOption) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepPhoneVerification) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepPhoneVerification)
 	}
 	resp, err := verifyPhone(ctx, "select-authenticator-authenticate", r.idxContext.InteractionHandle, option, "")
 	if err != nil {
@@ -240,7 +240,7 @@ func (r *LoginResponse) VerifyPhone(ctx context.Context, option PhoneOption) (*L
 // VerifyPhoneInitial Initial verify phone.
 func (r *LoginResponse) VerifyPhoneInitial(ctx context.Context, option PhoneOption, phoneNumber string) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepPhoneInitialVerification) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepPhoneInitialVerification)
 	}
 	resp, err := verifyPhone(ctx, "select-authenticator-enroll", r.idxContext.InteractionHandle, option, phoneNumber)
 	if err != nil {
@@ -289,7 +289,7 @@ func verifyPhone(ctx context.Context, remedOpt string, ih *InteractionHandle, ph
 // VerifyEmail Triggers email verification code emission.
 func (r *LoginResponse) VerifyEmail(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepEmailVerification) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepEmailVerification)
 	}
 	resp, err := verifyEmail(ctx, r.idxContext, "select-authenticator-authenticate")
 	if err != nil {
@@ -306,7 +306,7 @@ func (r *LoginResponse) VerifyEmail(ctx context.Context) (*LoginResponse, error)
 // ConfirmEmail Confirm the verified email with the given code that was emitted.
 func (r *LoginResponse) ConfirmEmail(ctx context.Context, code string) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepEmailConfirmation) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepEmailConfirmation)
 	}
 	return r.confirmWithCode(ctx, "challenge-authenticator", code)
 }
@@ -315,7 +315,7 @@ func (r *LoginResponse) ConfirmEmail(ctx context.Context, code string) (*LoginRe
 // when other steps are optional.
 func (r *LoginResponse) Skip(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepSkip) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepSkip)
 	}
 	resp, err := skip(ctx, r.idxContext.InteractionHandle)
 	if err != nil {
@@ -331,7 +331,7 @@ func (r *LoginResponse) Skip(ctx context.Context) (*LoginResponse, error) {
 // Cancel the whole login process.
 func (r *LoginResponse) Cancel(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepCancel) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepCancel)
 	}
 	resp, err := idx.introspect(ctx, r.idxContext.InteractionHandle)
 	if err != nil {
@@ -595,4 +595,16 @@ func enrollOktaVerify(ctx context.Context, handle *InteractionHandle, option Okt
 				}
 			}`)
 	return ro.proceed(ctx, authenticator)
+}
+
+func (r *LoginResponse) missingStepError(missingStep LoginStep) (*LoginResponse, error) {
+	steps := ""
+	for index, step := range r.availableSteps {
+		if index != 0 {
+			steps = fmt.Sprintf("%s, ", steps)
+		}
+		steps = fmt.Sprintf("%s%q", steps, step)
+
+	}
+	return nil, fmt.Errorf("%q login step is not available, please try one of %s", missingStep, steps)
 }

--- a/identify.go
+++ b/identify.go
@@ -578,3 +578,21 @@ func enrollGoogleAuth(ctx context.Context, handle *InteractionHandle) (*Response
 			}`)
 	return ro.proceed(ctx, authenticator)
 }
+
+func enrollOktaVerify(ctx context.Context, handle *InteractionHandle, option OktaVerifyOption) (*Response, error) {
+	resp, err := idx.introspect(ctx, handle)
+	if err != nil {
+		return nil, err
+	}
+	ro, authID, err := resp.authenticatorOption("select-authenticator-enroll", "Okta Verify", true)
+	if err != nil {
+		return nil, err
+	}
+	authenticator := []byte(`{
+				"authenticator": {
+					"id": "` + authID + `",
+					"channel": "` + string(option) + `"
+				}
+			}`)
+	return ro.proceed(ctx, authenticator)
+}

--- a/identify.go
+++ b/identify.go
@@ -630,7 +630,6 @@ func (r *LoginResponse) missingStepError(missingStep LoginStep) (*LoginResponse,
 			steps = fmt.Sprintf("%s, ", steps)
 		}
 		steps = fmt.Sprintf("%s%q", steps, step)
-
 	}
 	return nil, fmt.Errorf("%q login step is not available, please try one of %s", missingStep, steps)
 }

--- a/idx.go
+++ b/idx.go
@@ -439,6 +439,9 @@ func (c *Client) oAuthEndPoint(operation string) string {
 }
 
 func (c *Client) debugRequest(req *http.Request) {
+	if req == nil {
+		return
+	}
 	fmt.Fprintln(os.Stderr, "== IDX CLIENT DEBUG REQUEST  ======")
 	dump, err := httputil.DumpRequest(req, true)
 	if err == nil {
@@ -450,6 +453,9 @@ func (c *Client) debugRequest(req *http.Request) {
 }
 
 func (c *Client) debugResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
 	fmt.Fprintf(os.Stderr, "== IDX CLIENT DEBUG RESPONSE ======")
 	dump, err := httputil.DumpResponse(resp, true)
 	if err == nil {

--- a/idx.go
+++ b/idx.go
@@ -25,8 +25,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http/httputil"
 	"net/http"
 	"net/url"
+	"os"
 	"runtime"
 	"strings"
 	"time"
@@ -48,6 +50,7 @@ var idx *Client
 type Client struct {
 	config     *Config
 	httpClient *http.Client
+    debug bool
 }
 
 // NewClient New client constructor that is configured with configuration file
@@ -82,6 +85,10 @@ func NewClientWithSettings(conf ...ConfigSetter) (*Client, error) {
 		config:     cfg,
 		httpClient: &http.Client{Timeout: defaultTimeout},
 	}
+	if os.Getenv("DEBUG_IDX_CLIENT") != "" {
+		c.debug = true
+	}
+
 	idx = c
 	return c, nil
 }
@@ -119,7 +126,7 @@ func (c *Client) introspect(ctx context.Context, ih *InteractionHandle) (*Respon
 	req.Header.Add("Content-Type", "application/ion+json; okta-version=1.0.0")
 	req.Header.Add("Accept", "application/ion+json; okta-version=1.0.0")
 	withOktaUserAgent(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -170,7 +177,7 @@ func (c *Client) Interact(ctx context.Context) (*Context, error) {
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	withOktaUserAgent(req)
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -213,7 +220,7 @@ func (c *Client) RedeemInteractionCode(ctx context.Context, idxContext *Context,
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	withOktaUserAgent(req)
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("error calling token api: %w", err)
 	}
@@ -399,7 +406,7 @@ func (c *Client) RevokeToken(ctx context.Context, accessToken string) error {
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	withOktaUserAgent(req)
 
-	_, err := c.httpClient.Do(req)
+	_, err := c.httpClientDo(req)
 	return err
 }
 
@@ -412,4 +419,38 @@ func (c *Client) oAuthEndPoint(operation string) string {
 		endPoint = fmt.Sprintf("%s/oauth2/v1/%s", issuer, operation)
 	}
 	return endPoint
+}
+
+func (c *Client) debugRequest(req *http.Request) {
+	fmt.Fprintln(os.Stderr, "== IDX CLIENT DEBUG REQUEST  ======")
+	dump, err := httputil.DumpRequest(req, true)
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "%q\n", dump)
+	} else {
+		fmt.Fprintf(os.Stderr, "dump error: %+v", err)
+	}
+	fmt.Fprintln(os.Stderr, "===================================")
+}
+
+func (c *Client) debugResponse(resp *http.Response) {
+	fmt.Fprintf(os.Stderr, "== IDX CLIENT DEBUG RESPONSE ======")
+	dump, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		fmt.Fprintf(os.Stderr, "%q\n", dump)
+	} else {
+		fmt.Fprintf(os.Stderr, "dump error: %+v", err)
+	}
+	fmt.Fprintln(os.Stderr, "===================================")
+}
+
+func (c *Client) httpClientDo(req *http.Request) (*http.Response, error) {
+	if c.debug {
+		c.debugRequest(req)
+	}
+	resp, err := c.httpClient.Do(req)
+	if c.debug {
+		c.debugResponse(resp)
+	}
+
+	return resp, err
 }

--- a/option.go
+++ b/option.go
@@ -79,6 +79,7 @@ func (v *FormValue) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.DynamicValue)
 }
 
+//nolint:dupl
 // UnmarshallJSON Unmarshals FormValue JSON data.
 func (v *FormValue) UnmarshalJSON(data []byte) error {
 	type localIDX FormValue
@@ -131,6 +132,7 @@ type FormOptions struct {
 	RelatesTo    string           `json:"relatesTo"`
 }
 
+//nolint:dupl
 // UnmarshallJSON Unmarshals FormOptions JSON data.
 func (r *FormOptions) UnmarshalJSON(data []byte) error {
 	type localIDX FormOptions

--- a/option.go
+++ b/option.go
@@ -157,7 +157,7 @@ func (o *Option) proceed(ctx context.Context, data []byte) (*Response, error) {
 	req.Header.Set("Accepts", o.Accepts)
 	req.Header.Set("Content-Type", o.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClient.Do(req)
+	resp, err := idx.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -333,7 +333,7 @@ func (o *SuccessOption) exchangeCode(ctx context.Context, data []byte) (*Token, 
 	req.Header.Set("Accepts", o.Accepts)
 	req.Header.Set("Content-Type", o.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClient.Do(req)
+	resp, err := idx.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}

--- a/option_test.go
+++ b/option_test.go
@@ -1,3 +1,4 @@
+//go:build unit
 // +build unit
 
 /**
@@ -204,7 +205,7 @@ func TestRemediationOption_Proceed(t *testing.T) {
     "foo": "bar"
 }`)
 		respNext, err := resp.Remediation.RemediationOptions[0].proceed(context.TODO(), data)
-		assert.EqualError(t, err, `missing 'credentials' property from input`)
+		assert.Error(t, err)
 		assert.Nil(t, respNext)
 	})
 	t.Run("http_client_error", func(t *testing.T) {

--- a/reset_password.go
+++ b/reset_password.go
@@ -355,7 +355,7 @@ func (r *ResetPasswordResponse) setupNextSteps(ctx context.Context, resp *Respon
 				for j := range ro.FormValues[i].Form.FormValues {
 					if ro.FormValues[i].Form.FormValues[j].Name == questionKey {
 						r.sq = &SecurityQuestion{
-							QuestionKey: ro.FormValues[i].Form.FormValues[j].Value,
+							QuestionKey: ro.FormValues[i].Form.FormValues[j].Value.String(),
 							Question:    ro.FormValues[i].Form.FormValues[j].Label,
 						}
 						steps = append(steps, ResetPasswordStepAnswerSecurityQuestion)

--- a/reset_password.go
+++ b/reset_password.go
@@ -405,7 +405,6 @@ func (r *ResetPasswordResponse) missingStepError(missingStep ResetPasswordStep) 
 			steps = fmt.Sprintf("%s, ", steps)
 		}
 		steps = fmt.Sprintf("%s%q", steps, step)
-
 	}
 	return nil, fmt.Errorf("%q reset password step is not available, please try one of %s", missingStep, steps)
 }

--- a/response.go
+++ b/response.go
@@ -122,7 +122,7 @@ func (r *Response) Cancel(ctx context.Context) (*Response, error) {
 	req.Header.Set("Accepts", r.CancelResponse.Accepts)
 	req.Header.Set("Content-Type", r.CancelResponse.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClient.Do(req)
+	resp, err := idx.httpClientDo(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}

--- a/response.go
+++ b/response.go
@@ -182,7 +182,7 @@ func (r *Response) authenticatorOption(optionName, label string, modifyOptions b
 	var authID string
 	for _, ov := range v.Options {
 		if ov.Label == label {
-			authID = ov.Value.(FormOptionsValueObject).Form.Value[0].Value
+			authID = ov.Value.(FormOptionsValueObject).Form.Value[0].Value.String()
 			if modifyOptions {
 				v.Options = []FormOptions{ov}
 			}


### PR DESCRIPTION
Adds support for the Okta Verify authenticator in enrollment and login.

Treats available steps of the various responses as a unique set.

Add convenience to debug http requests and responses to/from the Okta API.