### PR TITLE
Okta Verify totp clean up

### DIFF
--- a/enroll.go
+++ b/enroll.go
@@ -314,7 +314,7 @@ func (r *EnrollmentResponse) ConfirmPhone(ctx context.Context, code string) (*En
 // WebAuthNSetup initiates WebAuthN setup
 func (r *EnrollmentResponse) WebAuthNSetup(ctx context.Context) (*EnrollmentResponse, error) {
 	if !r.HasStep(EnrollmentStepWebAuthNSetup) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(EnrollmentStepWebAuthNSetup)
 	}
 	err := r.enrollAuthenticator(ctx, "Security Key or Biometric")
 	if err != nil {
@@ -332,7 +332,7 @@ type WebAuthNVerifyCredentials struct {
 // WebAuthNVerify enrolls user's Security Key or Biometric
 func (r *EnrollmentResponse) WebAuthNVerify(ctx context.Context, credentials *WebAuthNVerifyCredentials) (*EnrollmentResponse, error) {
 	if !r.HasStep(EnrollmentStepWebAuthNVerify) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(EnrollmentStepWebAuthNVerify)
 	}
 	if credentials == nil {
 		return nil, errors.New("invalid credentials")

--- a/identify.go
+++ b/identify.go
@@ -619,6 +619,10 @@ func (r *LoginResponse) setupNextSteps(ctx context.Context, resp *Response) erro
 	if err == nil {
 		r.appendStep(LoginStepPhoneInitialVerification)
 	}
+	_, _, err = resp.authenticatorOption("select-authenticator-enroll", "Okta Verify", false)
+	if err == nil {
+		r.appendStep(LoginStepOktaVerify)
+	}
 	_, _, err = resp.authenticatorOption("select-authenticator-enroll", "Google Authenticator", false)
 	if err == nil {
 		r.appendStep(LoginStepGoogleAuthenticatorInitialVerification)

--- a/identify.go
+++ b/identify.go
@@ -216,7 +216,7 @@ func (r *LoginResponse) GoogleAuthConfirm(ctx context.Context, code string) (*Lo
 
 func (r *LoginResponse) WebAuthNSetup(ctx context.Context) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepWebAuthNSetup) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepWebAuthNSetup)
 	}
 	err := r.enrollAuthenticator(ctx, "Security Key or Biometric")
 	if err != nil {
@@ -228,7 +228,7 @@ func (r *LoginResponse) WebAuthNSetup(ctx context.Context) (*LoginResponse, erro
 
 func (r *LoginResponse) WebAuthNInitialVerify(ctx context.Context, credentials *WebAuthNVerifyCredentials) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepWebAuthNInitialVerify) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepWebAuthNInitialVerify)
 	}
 	if credentials == nil {
 		return nil, errors.New("invalid credentials")
@@ -287,7 +287,7 @@ type WebAuthNChallengeCredentials struct {
 
 func (r *LoginResponse) WebAuthNVerify(ctx context.Context, credentials *WebAuthNChallengeCredentials) (*LoginResponse, error) {
 	if !r.HasStep(LoginStepWebAuthNVerify) {
-		return nil, fmt.Errorf("this step is not available, please try one of %s", r.AvailableSteps())
+		return r.missingStepError(LoginStepWebAuthNVerify)
 	}
 	if credentials == nil {
 		return nil, errors.New("invalid credentials")

--- a/identify.go
+++ b/identify.go
@@ -227,11 +227,45 @@ func (r *LoginResponse) OktaVerifyConfirm(ctx context.Context, code string) (*Lo
 	defer func() {
 		r.contextualData = nil
 	}()
-	resp, err := r.confirmWithTotpCode(ctx, "challenge-authenticator", code)
-	if err != nil && strings.Contains(err.Error(), "could not locate a remediation option with the name 'challenge-authenticator'") {
-		return r.confirmWithTotpCode(ctx, "enroll-authenticator", code)
+	resp, err := idx.introspect(ctx, r.idxContext.InteractionHandle)
+	if err != nil {
+		return nil, err
 	}
-	return resp, err
+	ro, authID, err := resp.authenticatorOption("select-authenticator-authenticate", "Okta Verify", true)
+	if err != nil {
+		return nil, err
+	}
+	authenticator := []byte(`{
+				"authenticator": {
+					"id": "` + authID + `",
+					"methodType": "totp"
+				}
+			}`)
+	resp, err = ro.proceed(ctx, authenticator)
+	if err != nil {
+		return nil, err
+	}
+
+	ro, err = resp.remediationOption("challenge-authenticator")
+	if err != nil {
+		return nil, err
+	}
+
+	credentials := []byte(fmt.Sprintf(`{
+				"credentials": {
+					"totp": "%s"
+				}
+			}`, strings.TrimSpace(code)))
+	resp, err = ro.proceed(ctx, credentials)
+	if err != nil {
+		return nil, err
+	}
+
+	err = r.setupNextSteps(ctx, resp)
+	if err != nil {
+		return nil, err
+	}
+	return r, err
 }
 
 // GoogleAuthInitialVerify initiates Google Authenticator setup for the existing user in case this authenticator
@@ -698,15 +732,6 @@ func (r *LoginResponse) setupNextSteps(ctx context.Context, resp *Response) erro
 		return fmt.Errorf("there are no more steps available: %+v", resp.Messages.Values)
 	}
 	return nil
-}
-
-func (r *LoginResponse) confirmWithTotpCode(ctx context.Context, remediationOpt, code string) (*LoginResponse, error) {
-	resp, err := totpAuth(ctx, r.idxContext, remediationOpt, code)
-	if err != nil {
-		return nil, err
-	}
-	err = r.setupNextSteps(ctx, resp)
-	return r, err
 }
 
 func (r *LoginResponse) confirmWithCode(ctx context.Context, remediationOpt, code string) (*LoginResponse, error) {

--- a/idx.go
+++ b/idx.go
@@ -382,23 +382,6 @@ func createState() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(localState), nil
 }
 
-func totpAuth(ctx context.Context, idxContext *Context, remediation, passcode string) (*Response, error) {
-	resp, err := idx.introspect(ctx, idxContext.InteractionHandle)
-	if err != nil {
-		return nil, err
-	}
-	ro, err := resp.remediationOption(remediation)
-	if err != nil {
-		return nil, err
-	}
-	credentials := []byte(fmt.Sprintf(`{
-				"credentials": {
-					"totp": "%s"
-				}
-			}`, strings.TrimSpace(passcode)))
-	return ro.proceed(ctx, credentials)
-}
-
 func passcodeAuth(ctx context.Context, idxContext *Context, remediation, passcode string) (*Response, error) {
 	resp, err := idx.introspect(ctx, idxContext.InteractionHandle)
 	if err != nil {


### PR DESCRIPTION
This ended up being some clean up and nice to haves. `OktaVerifyConfirm` was either broken or not implemented correctly. Cleaned that up. Added convenience `OktaVerifyMethodTypes` to help with the display in the samples app where Okta Verify is being presented.