### PR TITLE
Improve debug logging

### DIFF
--- a/idx.go
+++ b/idx.go
@@ -26,11 +26,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
-	"os"
 	"runtime"
 	"strconv"
 	"strings"
@@ -63,7 +60,6 @@ type AccessToken struct {
 type Client struct {
 	config     *Config
 	httpClient *http.Client
-	debug      bool
 }
 
 type Context struct {
@@ -112,11 +108,11 @@ func NewClientWithSettings(conf ...ConfigSetter) (*Client, error) {
 		return nil, fmt.Errorf("invalid configuration: %w", err)
 	}
 	c := &Client{
-		config:     cfg,
-		httpClient: &http.Client{Timeout: defaultTimeout},
-	}
-	if os.Getenv("DEBUG_IDX_CLIENT") != "" {
-		c.debug = true
+		config: cfg,
+		httpClient: &http.Client{
+			Transport: newIdxTransport(),
+			Timeout:   defaultTimeout,
+		},
 	}
 
 	idx = c
@@ -156,7 +152,7 @@ func (c *Client) introspect(ctx context.Context, ih *InteractionHandle) (*Respon
 	req.Header.Add("Content-Type", "application/ion+json; okta-version=1.0.0")
 	req.Header.Add("Accept", "application/ion+json; okta-version=1.0.0")
 	withOktaUserAgent(req)
-	resp, err := c.httpClientDo(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -201,7 +197,7 @@ func (c *Client) interact(ctx context.Context, opts *interactOptions) (*Context,
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	withDeviceContext(ctx, req)
 
-	resp, err := c.httpClientDo(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -254,7 +250,7 @@ func (c *Client) RedeemInteractionCode(ctx context.Context, idxContext *Context,
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	withOktaUserAgent(req)
 
-	resp, err := c.httpClientDo(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error calling token api: %w", err)
 	}
@@ -570,63 +566,3 @@ func securityQuestionOptions(ctx context.Context, idxContext *Context) (*Respons
 	m["custom"] = "Create a security question"
 	return resp, m, nil
 }
-
-func (c *Client) debugRequest(req *http.Request) {
-	if req == nil {
-		return
-	}
-	reqData, err := httputil.DumpRequest(req, true)
-	if err == nil {
-		log.Printf("[DEBUG] "+logReqMsg, req.RequestURI, prettyPrintJsonLines(reqData))
-	} else {
-		log.Printf("[ERROR] %s API Request error: %#v", req.RequestURI, err)
-	}
-}
-
-func (c *Client) debugResponse(resp *http.Response) {
-	if resp == nil {
-		return
-	}
-	respData, err := httputil.DumpResponse(resp, true)
-	if err == nil {
-		log.Printf("[DEBUG] "+logRespMsg, resp.Request.RequestURI, prettyPrintJsonLines(respData))
-	} else {
-		log.Printf("[ERROR] %s API Response error: %#v", resp.Request.RequestURI, err)
-	}
-}
-
-func (c *Client) httpClientDo(req *http.Request) (*http.Response, error) {
-	if c.debug {
-		c.debugRequest(req)
-	}
-	resp, err := c.httpClient.Do(req)
-	if c.debug {
-		c.debugResponse(resp)
-	}
-
-	return resp, err
-}
-
-// prettyPrintJsonLines iterates through a []byte line-by-line, transforming any
-// lines that are complete json into pretty-printed json.
-func prettyPrintJsonLines(b []byte) string {
-	parts := strings.Split(string(b), "\n")
-	for i, p := range parts {
-		if b := []byte(p); json.Valid(b) {
-			var out bytes.Buffer
-			json.Indent(&out, b, "", " ")
-			parts[i] = out.String()
-		}
-	}
-	return strings.Join(parts, "\n")
-}
-
-const logReqMsg = `%s API Request Details:
----[ REQUEST ]---------------------------------------
-%s
------------------------------------------------------`
-
-const logRespMsg = `%s API Response Details:
----[ RESPONSE ]--------------------------------------
-%s
------------------------------------------------------`

--- a/net.go
+++ b/net.go
@@ -32,7 +32,7 @@ func debugRequest(req *http.Request) {
 	}
 	reqData, err := httputil.DumpRequest(req, true)
 	if err == nil {
-		log.Printf("[DEBUG] "+logReqMsg, req.RequestURI, prettyPrintJsonLines(reqData))
+		log.Printf("[DEBUG] "+logReqMsg, req.RequestURI, prettyPrintJSONLines(reqData))
 	} else {
 		log.Printf("[ERROR] %s API Request error: %#v", req.RequestURI, err)
 	}
@@ -44,20 +44,20 @@ func debugResponse(resp *http.Response) {
 	}
 	respData, err := httputil.DumpResponse(resp, true)
 	if err == nil {
-		log.Printf("[DEBUG] "+logRespMsg, resp.Request.RequestURI, prettyPrintJsonLines(respData))
+		log.Printf("[DEBUG] "+logRespMsg, resp.Request.RequestURI, prettyPrintJSONLines(respData))
 	} else {
 		log.Printf("[ERROR] %s API Response error: %#v", resp.Request.RequestURI, err)
 	}
 }
 
-// prettyPrintJsonLines iterates through a []byte line-by-line, transforming any
+// prettyPrintJSONLines iterates through a []byte line-by-line, transforming any
 // lines that are complete json into pretty-printed json.
-func prettyPrintJsonLines(b []byte) string {
+func prettyPrintJSONLines(b []byte) string {
 	parts := strings.Split(string(b), "\n")
 	for i, p := range parts {
 		if b := []byte(p); json.Valid(b) {
 			var out bytes.Buffer
-			json.Indent(&out, b, "", " ")
+			_ = json.Indent(&out, b, "", " ")
 			parts[i] = out.String()
 		}
 	}

--- a/net.go
+++ b/net.go
@@ -1,0 +1,101 @@
+/**
+ * Copyright (c) 2021-Present, Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package idx
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"os"
+	"strings"
+)
+
+func debugRequest(req *http.Request) {
+	if req == nil {
+		return
+	}
+	reqData, err := httputil.DumpRequest(req, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logReqMsg, req.RequestURI, prettyPrintJsonLines(reqData))
+	} else {
+		log.Printf("[ERROR] %s API Request error: %#v", req.RequestURI, err)
+	}
+}
+
+func debugResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	respData, err := httputil.DumpResponse(resp, true)
+	if err == nil {
+		log.Printf("[DEBUG] "+logRespMsg, resp.Request.RequestURI, prettyPrintJsonLines(respData))
+	} else {
+		log.Printf("[ERROR] %s API Response error: %#v", resp.Request.RequestURI, err)
+	}
+}
+
+// prettyPrintJsonLines iterates through a []byte line-by-line, transforming any
+// lines that are complete json into pretty-printed json.
+func prettyPrintJsonLines(b []byte) string {
+	parts := strings.Split(string(b), "\n")
+	for i, p := range parts {
+		if b := []byte(p); json.Valid(b) {
+			var out bytes.Buffer
+			json.Indent(&out, b, "", " ")
+			parts[i] = out.String()
+		}
+	}
+	return strings.Join(parts, "\n")
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+type idxTransport struct {
+	rt    http.RoundTripper
+	debug bool
+}
+
+func newIdxTransport() *idxTransport {
+	it := idxTransport{
+		rt:    &http.Transport{},
+		debug: (os.Getenv("DEBUG_IDX_CLIENT") != ""),
+	}
+
+	return &it
+}
+
+func (it *idxTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if it.debug {
+		debugRequest(r)
+	}
+	resp, err := it.rt.RoundTrip(r)
+	if it.debug {
+		debugResponse(resp)
+	}
+
+	return resp, err
+}

--- a/option.go
+++ b/option.go
@@ -206,7 +206,7 @@ func (o *Option) proceed(ctx context.Context, data []byte) (*Response, error) {
 	req.Header.Set("Accepts", o.Accepts)
 	req.Header.Set("Content-Type", o.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClientDo(req)
+	resp, err := idx.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}
@@ -382,7 +382,7 @@ func (o *SuccessOption) exchangeCode(ctx context.Context, data []byte) (*Token, 
 	req.Header.Set("Accepts", o.Accepts)
 	req.Header.Set("Content-Type", o.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClientDo(req)
+	resp, err := idx.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}

--- a/response.go
+++ b/response.go
@@ -123,7 +123,7 @@ func (r *Response) Cancel(ctx context.Context) (*Response, error) {
 	req.Header.Set("Accepts", r.CancelResponse.Accepts)
 	req.Header.Set("Content-Type", r.CancelResponse.Accepts)
 	withOktaUserAgent(req)
-	resp, err := idx.httpClientDo(req)
+	resp, err := idx.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http call has failed: %w", err)
 	}


### PR DESCRIPTION
Nothing needed to be added for the OIE magic link features here. Instead, this cleans up http request and response logging to use a net http round trip transport on the client. Formats logging nice and pretty such as done in the Terraform runtime.